### PR TITLE
Small Screen Alternating Section Background Fix

### DIFF
--- a/main.css
+++ b/main.css
@@ -189,8 +189,7 @@ section {
   padding: 20px;
 }
 /* small screen background variation - every other section is white */
-section:nth-of-type(2n),
-#sidebar section:nth-of-type(2n-1) {
+section:nth-of-type(2n) {
   background-color: transparent;
 }
 


### PR DESCRIPTION
Since &lt;main&gt; now has an even number of sections, tweaked the selector on lines 192 and 193 of main.css to preserve the alternating background pattern on small screens between the #publications and #bioelectricity-seminars sections. 

The change in this commit would need to be undone if &lt;main&gt; went back to having an odd number of sections (my apologies, it is a quirk of using alternating backgrounds with a two column layout).